### PR TITLE
POST Request JSON encoding

### DIFF
--- a/src/SupportBee/API.php
+++ b/src/SupportBee/API.php
@@ -60,7 +60,7 @@ class API {
 		if ( strtoupper($method) == 'GET' )
 			return Requests::get(SupportBee::$base_url.$path.'?'.http_build_query( $options ), SupportBee::$headers, $options);
 		else if ( strtoupper($method) == 'POST' )
-			return Requests::post(SupportBee::$base_url.$path, SupportBee::$headers, $options);
+			return Requests::post(SupportBee::$base_url.$path, SupportBee::$headers, json_encode($options));
 		else if ( strtoupper($method) == 'DELETE' )
 			return Requests::delete(SupportBee::$base_url.$path.'?'.http_build_query( $options ), SupportBee::$headers, $options);
 		else


### PR DESCRIPTION
- The data passed to the Requests::post method was not properly JSON encoded
  before passing. This resulted in the data being encoded with http_build_query
  by the Requests class as the data was not a string. The improperly formatted
  data caused POST requests to the SupportBee API to fail with an error.
- Properly JSON encoding the data before passing it to the Requests::post method
  fixes the error.
