### PR TITLE
added ticket labeling methods, fixed php warnings about static method…

### DIFF
--- a/src/SupportBee/API.php
+++ b/src/SupportBee/API.php
@@ -19,7 +19,7 @@ class API {
 		500 => '500: Some error occured at SupportBee servers.'
 	);
 
-	protected function validate( $options = array(), $valid = array(), $required = array() )
+	protected static function validate( $options = array(), $valid = array(), $required = array() )
 	{
 		if ( !is_array($options) )
 			throw new InvalidArgumentException( 'Parameters need to be passed as array' );
@@ -36,7 +36,7 @@ class API {
 			throw new InvalidArgumentException( 'Required parameter not passed' );
 	}
 
-	protected function tfTostring(&$value,&$key)
+	protected static function tfTostring(&$value,&$key)
 	{
 		if ($value === true)
 		{
@@ -48,14 +48,14 @@ class API {
 		}
 	}
 
-	protected function inject( &$options )
+	protected static function inject( &$options )
 	{
 		$options = array_merge( $options, array(
 			'auth_token' => SupportBee::$auth_token
 		));
 	}
 
-	private function request( $path, $options, $method = 'GET' )
+	private static function request( $path, $options, $method = 'GET' )
 	{
 		if ( strtoupper($method) == 'GET' )
 			return Requests::get(SupportBee::$base_url.$path.'?'.http_build_query( $options ), SupportBee::$headers, $options);
@@ -67,7 +67,7 @@ class API {
 			throw new Exception( 'Unknown HTTP request method' );
 	}
 
-	protected function handle_response( $resp )
+	protected static function handle_response( $resp )
 	{
 		if( $resp->status_code != 200 )
 		{
@@ -85,7 +85,7 @@ class API {
 			return json_decode($resp->body, true);
 	}
 
-	protected function process_request( $path, $options = array(), $method = 'GET' )
+	protected static function process_request( $path, $options = array(), $method = 'GET' )
 	{
 		self::inject( $options );
 		array_walk($options,'self::tfTostring');

--- a/src/SupportBee/API/Tickets.php
+++ b/src/SupportBee/API/Tickets.php
@@ -102,4 +102,14 @@ class Tickets extends API {
 	{
 		return self::process_request( 'tickets/'.$id.'/trash', array(), 'DELETE' );
 	}
+	
+	public static function add_label( $id, $label )
+	{
+		return self::process_request( 'tickets/'.$id.'/labels/'.$label, array(), 'POST' );
+	}
+	
+	public static function remove_label( $id, $label )
+	{
+		return self::process_request( 'tickets/'.$id.'/labels/'.$label, array(), 'DELETE' );
+	}
 }

--- a/src/SupportBee/SupportBee.php
+++ b/src/SupportBee/SupportBee.php
@@ -122,6 +122,16 @@ class SupportBee
 	{
 		return Tickets::untrash_ticket( $id );
 	}
+	
+	public function addLabelToTicket( $id = 0, $label = '' )
+	{
+		return Tickets::add_label( $id, $label );
+	}
+	
+	public function removeLabelFromTicket( $id = 0, $label = '' )
+	{
+		return Tickets::remove_label( $id, $label );
+	}
 
 	public function searchTickets( $options = array() )
 	{


### PR DESCRIPTION
… calls

I was getting a lot of warnings from PHP about accessing non-static methods (from API class) in a static way. Changing the methods to "static" in the API class fixed that.

I also added the add/delete label from ticket API methods to Tickets.php
